### PR TITLE
Change the editable bid insights permission so anyone can edit it

### DIFF
--- a/src/views/Bid/Bid.tsx
+++ b/src/views/Bid/Bid.tsx
@@ -3,7 +3,6 @@ import withAuth from "../../routes/withAuth";
 import BidNavbar from "@/views/Bid/components/BidNavbar";
 import { BidContext } from "../BidWritingStateManagerView";
 import BreadcrumbNavigation from "@/layout/BreadCrumbNavigation";
-import { toast } from "react-toastify";
 import BidPlanner from "../BidPlanner/BidPlanner";
 import BidIntel from "../BidInputs/BidIntel";
 import ProposalWorkspace from "./components/ProposalWorkspace";
@@ -94,10 +93,6 @@ const Bid = () => {
       };
     }
   }, []);
-
-  const showViewOnlyMessage = () => {
-    toast.error("You only have permission to view this bid.");
-  };
 
   const handleTabClick = (
     path: string,
@@ -279,9 +274,7 @@ const Bid = () => {
                   setActiveSubTab={setActiveSubTab}
                 />
               )}
-              {activeTab === "/bid-intel" && (
-                <BidIntel showViewOnlyMessage={showViewOnlyMessage} />
-              )}
+              {activeTab === "/bid-intel" && <BidIntel />}
               {(activeTab === "/proposal-planner" ||
                 activeTab === "/proposal-preview") && (
                 <ProposalWorkspace
@@ -295,10 +288,10 @@ const Bid = () => {
                   activeTab={activeTab}
                 />
               )}
-               {(activeTab === "/full-proposal") && (
-                 <FullProposal   handleTabClick={handleTabClick}/>
+              {activeTab === "/full-proposal" && (
+                <FullProposal handleTabClick={handleTabClick} />
               )}
-               
+
               <OutlineInstructionsModal
                 show={showModal}
                 onHide={() => setShowModal(false)}

--- a/src/views/BidInputs/BidIntel.tsx
+++ b/src/views/BidInputs/BidIntel.tsx
@@ -23,16 +23,11 @@ import { useUserData } from "@/context/UserDataContext";
 import AIChatDialog from "./AIChatDialog";
 import Solution from "./Solution";
 
-const BidIntel = ({
-  showViewOnlyMessage
-}: {
-  showViewOnlyMessage: () => void;
-}) => {
+const BidIntel = () => {
   const getAuth = useAuthUser();
   const auth = useMemo(() => getAuth(), [getAuth]);
 
   const { sharedState, setSharedState } = useContext(BidContext);
-  const { contributors } = sharedState;
 
   // State for inline editing
   const [editingState, setEditingState] = useState({
@@ -51,27 +46,13 @@ const BidIntel = ({
     factors: sharedState.differentiating_factors || []
   };
 
-  const currentUserPermission = contributors[auth?.email] || "viewer";
-
-  const canUserEdit =
-    currentUserPermission === "admin" || currentUserPermission === "editor";
-
   const { userProfile, organizationUsers, isLoading } = useUserData();
 
   const handleEditStart = (text: string, type: string, index: number) => {
-    if (!canUserEdit) {
-      showViewOnlyMessage();
-      return;
-    }
     setEditingState({ type, index, text });
   };
 
   const handleDelete = (type: string, index: number) => {
-    if (!canUserEdit) {
-      showViewOnlyMessage();
-      return;
-    }
-
     const updatedState = { ...sharedState };
 
     switch (type) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
  - Simplified the Bid view by removing permission-based editing restrictions and related messaging.
  - All users can now initiate edits and deletions in the BidIntel component without encountering view-only messages.
  - Streamlined component interfaces for easier usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->