### PR TITLE
When there is a generated section, it goes straight to 'write' when y…

### DIFF
--- a/src/views/Bid/components/ProposalWorkspace.tsx
+++ b/src/views/Bid/components/ProposalWorkspace.tsx
@@ -89,8 +89,18 @@ const ProposalWorkspace = ({
     if (index !== -1) {
       setActiveSectionIndex(index);
       handleActiveSectionChange(outline[index].section_id);
+
+      // Check if the section has content and set view to "write" if it does
+      const currentSection = outline[index];
+      if (
+        currentSection &&
+        currentSection.answer &&
+        currentSection.answer.trim() !== ""
+      ) {
+        setActiveView("write");
+      }
     }
-  }, [activeSectionId, outline]);
+  }, [activeSectionId, outline, handleActiveSectionChange]);
 
   const handleSectionChange = async (
     index: number,


### PR DESCRIPTION
…ou are clicking on the section, instead of 'plan'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- The view now automatically switches to "write" mode when navigating to a section that already contains content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->