### PR TITLE
When full proposal has been generated, or a section has been generate…

### DIFF
--- a/src/components/GenerateSectionButton.tsx
+++ b/src/components/GenerateSectionButton.tsx
@@ -79,7 +79,8 @@ const GenerateSectonButton: React.FC<GenerateSectonButtonProps> = ({
           if (sectionIndex !== -1) {
             updatedOutline[sectionIndex] = {
               ...updatedOutline[sectionIndex],
-              answer: response.data // This should now correctly assign the answer text
+              answer: response.data,
+              status: "In Progress"
             };
           }
           return {

--- a/src/modals/GenerateProposalModal.tsx
+++ b/src/modals/GenerateProposalModal.tsx
@@ -4,7 +4,7 @@ import axios from "axios";
 import { useAuthUser } from "react-auth-kit";
 import { faCheckCircle, faSpinner } from "@fortawesome/free-solid-svg-icons";
 import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
-import { BidContext } from "../views/BidWritingStateManagerView";
+import { BidContext, Section } from "../views/BidWritingStateManagerView";
 import { useProposalGeneration } from "@/context/ProposalGenerationContext";
 import { Progress } from "@/components/ui/progress";
 import {
@@ -186,11 +186,30 @@ const GenerateProposalModal = ({
         }
       );
 
-      // Update shared state with outline data
-      setSharedState((prevState) => ({
-        ...prevState,
-        outline: response.data?.updated_outline || []
-      }));
+      // Update shared state with outline data and set all sections to "In Progress"
+      setSharedState((prevState) => {
+        // Get the updated outline from the response
+        let updatedOutline = response.data?.updated_outline || [];
+        
+        // If no updated outline was returned, use the current outline and update status
+        if (!updatedOutline.length && prevState.outline && prevState.outline.length) {
+          updatedOutline = prevState.outline.map((section: Section) => ({
+            ...section,
+            status: "In Progress"
+          }));
+        } else if (updatedOutline.length) {
+          // If we have an updated outline, ensure all sections have "In Progress" status
+          updatedOutline = updatedOutline.map((section: Section) => ({
+            ...section,
+            status: "In Progress"
+          }));
+        }
+        
+        return {
+          ...prevState,
+          outline: updatedOutline
+        };
+      });
 
       setProgress(100);
       setCurrentStep(2); // Move to success step


### PR DESCRIPTION
…d, the status of the question automatically goes to 'in progress'

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Enhancements**
  - Improved status updates for proposal sections, ensuring that sections are now consistently marked as "In Progress" after generation.
  - Enhanced outline handling so that all sections reflect their current status more accurately during the generation process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->